### PR TITLE
Implement acid-panel Foxx microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # ArangoPanel
+
+This repository contains a Foxx microservice called **acid-panel**. The service provides a visual interface for creating ArangoDB collections and schemas using pure HTML and JavaScript. All files are static and can be installed directly in ArangoDB without build steps.
+
+Mount the service under `/acid-panel` and open the interface to create collections with field definitions, Joi validations and relations.
+

--- a/acid-panel/frontend/index.html
+++ b/acid-panel/frontend/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Acid Panel</title>
+  <style>
+    table { border-collapse: collapse; margin-bottom: 1em; }
+    th, td { border: 1px solid #ccc; padding: 4px; }
+  </style>
+</head>
+<body>
+  <button id="showInterface">Show Interface</button>
+  <div id="interface" style="display:none;">
+    <h1>Create Collection</h1>
+    <label>Collection Name: <input id="collectionName"></label>
+
+    <h2>Fields</h2>
+    <table id="fieldsTable">
+      <thead>
+        <tr><th>Name</th><th>Type</th><th>Required</th><th>Validations (JSON)</th><th></th></tr>
+      </thead>
+      <tbody>
+        <tr class="fieldRow">
+          <td><input class="fieldName"></td>
+          <td>
+            <select class="fieldType">
+              <option value="string">string</option>
+              <option value="number">number</option>
+              <option value="boolean">boolean</option>
+            </select>
+          </td>
+          <td><input type="checkbox" class="fieldRequired"></td>
+          <td><input class="fieldValidations" placeholder='{"min":2}'></td>
+          <td><button class="removeField">Remove</button></td>
+        </tr>
+      </tbody>
+    </table>
+    <button id="addField">Add Field</button>
+
+    <h2>Relations</h2>
+    <table id="relationsTable">
+      <thead>
+        <tr><th>Field</th><th>Ref Collection</th><th>Ref Field</th><th>onDelete</th><th></th></tr>
+      </thead>
+      <tbody>
+        <tr class="relationRow">
+          <td><input class="relField"></td>
+          <td><input class="relRefCollection"></td>
+          <td><input class="relRefField" value="_key"></td>
+          <td>
+            <select class="relOnDelete">
+              <option value="cascade">cascade</option>
+              <option value="restrict">restrict</option>
+              <option value="ignore">ignore</option>
+            </select>
+          </td>
+          <td><button class="removeRelation">Remove</button></td>
+        </tr>
+      </tbody>
+    </table>
+    <button id="addRelation">Add Relation</button>
+    <br><br>
+    <button id="createBtn">Create</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/acid-panel/frontend/script.js
+++ b/acid-panel/frontend/script.js
@@ -1,0 +1,54 @@
+const showButton = document.getElementById('showInterface');
+const panel = document.getElementById('interface');
+showButton.addEventListener('click', () => {
+  panel.style.display = 'block';
+  showButton.style.display = 'none';
+});
+
+function addFieldRow() {
+  const row = document.querySelector('#fieldsTable tbody tr').cloneNode(true);
+  row.querySelectorAll('input').forEach(i => i.value = '');
+  row.querySelector('.fieldRequired').checked = false;
+  row.querySelector('.removeField').addEventListener('click', () => row.remove());
+  document.querySelector('#fieldsTable tbody').appendChild(row);
+}
+
+function addRelationRow() {
+  const row = document.querySelector('#relationsTable tbody tr').cloneNode(true);
+  row.querySelectorAll('input').forEach(i => i.value = '');
+  row.querySelector('.relOnDelete').value = 'cascade';
+  row.querySelector('.removeRelation').addEventListener('click', () => row.remove());
+  document.querySelector('#relationsTable tbody').appendChild(row);
+}
+
+// attach remove handler to initial rows
+document.querySelectorAll('.removeField').forEach(btn => btn.addEventListener('click', e => e.target.closest('tr').remove()));
+document.querySelectorAll('.removeRelation').forEach(btn => btn.addEventListener('click', e => e.target.closest('tr').remove()));
+
+document.getElementById('addField').addEventListener('click', addFieldRow);
+document.getElementById('addRelation').addEventListener('click', addRelationRow);
+
+document.getElementById('createBtn').addEventListener('click', async () => {
+  const name = document.getElementById('collectionName').value.trim();
+  const fields = Array.from(document.querySelectorAll('#fieldsTable tbody tr')).map(row => ({
+    name: row.querySelector('.fieldName').value,
+    type: row.querySelector('.fieldType').value,
+    required: row.querySelector('.fieldRequired').checked,
+    validations: row.querySelector('.fieldValidations').value
+  }));
+  const relations = Array.from(document.querySelectorAll('#relationsTable tbody tr')).map(row => ({
+    field: row.querySelector('.relField').value,
+    refCollection: row.querySelector('.relRefCollection').value,
+    refField: row.querySelector('.relRefField').value,
+    onDelete: row.querySelector('.relOnDelete').value
+  }));
+  const payload = { name, fields, relations };
+  const res = await fetch('api/collections', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  alert(data.success ? 'Collection created' : 'Error');
+});
+

--- a/acid-panel/index.js
+++ b/acid-panel/index.js
@@ -1,0 +1,98 @@
+'use strict';
+const db = require('@arangodb').db;
+const joi = require('joi');
+const request = require('@arangodb/request');
+const createRouter = require('@arangodb/foxx/router');
+
+const router = createRouter();
+module.context.use(router);
+
+router.get('/', (req, res) => {
+  res.redirect(module.context.mount + '/frontend/index.html');
+});
+
+router.post('/api/collections', (req, res) => {
+  const { name, fields = [], relations = [], testDocument } = req.body;
+  if (!name) {
+    res.throw('bad request', 'name required');
+  }
+
+  // Create collection if it doesn't exist
+  let col = db._collection(name);
+  if (!col) {
+    col = db._create(name);
+  }
+
+  // Build Joi schema
+  const schemaObj = {};
+  fields.forEach(f => {
+    let fieldSchema = joi;
+    switch (f.type) {
+      case 'number':
+        fieldSchema = fieldSchema.number();
+        break;
+      case 'boolean':
+        fieldSchema = fieldSchema.boolean();
+        break;
+      default:
+        fieldSchema = fieldSchema.string();
+    }
+    if (f.required) fieldSchema = fieldSchema.required();
+    if (f.validations) {
+      try {
+        const rules = JSON.parse(f.validations);
+        Object.keys(rules).forEach(k => {
+          if (typeof fieldSchema[k] === 'function') {
+            const val = Array.isArray(rules[k]) ? rules[k] : [rules[k]];
+            fieldSchema = fieldSchema[k](...val);
+          }
+        });
+      } catch (err) {
+        /* ignore bad validation */
+      }
+    }
+    schemaObj[f.name] = fieldSchema;
+  });
+
+  // Save schema
+  const schemas = db._collection('schemas_config') || db._create('schemas_config');
+  schemas.save({ collection: name, schema: JSON.stringify(schemaObj) });
+
+  // Save relations
+  if (relations.length) {
+    const rels = db._collection('relations_config') || db._create('relations_config');
+    relations.forEach(rel => {
+      rel.collection = name;
+      rels.save(rel);
+    });
+  }
+
+  // Optional dummy insert via ArangoACID
+  if (testDocument) {
+    const acidUrl = module.context.configuration.acidUrl.replace(/\/$/, '');
+    try {
+      request.post(`${acidUrl}/${name}`, { json: testDocument });
+    } catch (err) {
+      // ignore errors from dummy insert
+    }
+  }
+
+  res.send({ success: true });
+})
+.body(joi.object({
+  name: joi.string().required(),
+  fields: joi.array().items(joi.object({
+    name: joi.string().required(),
+    type: joi.string().required(),
+    required: joi.boolean().optional(),
+    validations: joi.string().allow('').optional()
+  })).optional(),
+  relations: joi.array().items(joi.object({
+    field: joi.string().required(),
+    refCollection: joi.string().required(),
+    refField: joi.string().required(),
+    onDelete: joi.string().optional()
+  })).optional(),
+  testDocument: joi.object().optional()
+}).required(), 'collection definition');
+

--- a/acid-panel/manifest.json
+++ b/acid-panel/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "acid-panel",
+  "version": "1.0.0",
+  "description": "Visual panel for creating ArangoDB collections and schemas",
+  "author": "ArangoPanel",
+  "engines": {
+    "arangodb": "^3.9.0"
+  },
+  "main": "index.js",
+  "defaultDocument": "frontend/index.html",
+  "files": {
+    "path": "frontend"
+  },
+  "configuration": {
+    "acidUrl": {
+      "type": "string",
+      "default": "http://localhost:8529/acid",
+      "description": "Base URL of ArangoACID microservice"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Foxx microservice `acid-panel`
- include static HTML/JS frontend for building collections
- implement API endpoint to create collections and store schema/relations
- document usage in README